### PR TITLE
Add support for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ Object.assign(exports, {
 	}
 });
 
+// ensure a path is using forward slashes
+function slash(path) {
+	return path.split(Path.sep).join('/')
+}
 function prepare(obj, globalOpts) {
 	let list = [];
 	Object.keys(obj).forEach((input) => {
@@ -111,7 +115,7 @@ function command(cmd, input, output, options = {}, opts = {}) {
 	assertRooted(opts.cwd, destDir);
 
 	return fs.mkdir(destDir, { recursive: true }).then(() => {
-		return glob(srcPath, {
+		return glob(slash(srcPath), {
 			nosort: true,
 			nobrace: true,
 			noext: true,

--- a/test/fixtures/.gitattributes
+++ b/test/fixtures/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure fixture files have LF and not CRLF line endings
+* text=auto eol=lf


### PR DESCRIPTION
Fixes #10

This PR fixes the library on Windows.

It replaces backslash with forward slashes before calling `glob()`, [as required by the glob library](https://github.com/isaacs/node-glob/tree/v8.1.0?tab=readme-ov-file#windows):

> You must use forward-slashes only in glob expressions. Back-slashes will always be interpreted as escape characters, not path separators.

It also ensures git checks out fixtures files with the right line ending so that the test can pass.