### PR TITLE
Fix Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function parsePath(str) {
 function findRoot(name, path) {
 	if (Path.extname(path) != "") path = Path.dirname(path);
 	if (name == ".") return path;
-	path += '/';
+	path = slash(path) + '/';
 	const comp = '/' + name + '/';
 	const index = path.lastIndexOf(comp);
 	if (index < 0) return;


### PR DESCRIPTION
Hi Jérémy,

Running `postinstall` on Windows gave the following error:

```text
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at Object.join (node:path:460:7)
    at command (...\node_modules\postinstall\index.js:112:30)
    at async Promise.all (index 0)
    at async ...\node_modules\postinstall\bin\postinstall.js:28:3 {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

As with #10, it was due to the code assuming that the path separator is a forward slash.
As in #11, I fixed it by replacing the backslashes with forward slashes.

@kapouer, do you want me to create another PR to set up a GitHub workflow that would run the test on multiple platforms so as to avoid breaking Windows support again in the future?

Best regards,
Benoit